### PR TITLE
Switch to dynamic rendering for blog and post pages

### DIFF
--- a/src/app/[lng]/blog/page.tsx
+++ b/src/app/[lng]/blog/page.tsx
@@ -13,8 +13,7 @@ import { TopArticles } from '@/components/Blog/TopArticles'
 
 import PageClient from './page.client'
 
-export const dynamic = 'force-static'
-export const revalidate = 600
+export const dynamic = 'force-dynamic'
 
 type Args = {
   params: Promise<{ lng: string }>

--- a/src/app/[lng]/blog/posts/[slug]/page.tsx
+++ b/src/app/[lng]/blog/posts/[slug]/page.tsx
@@ -13,24 +13,23 @@ import RichText from '@/components/RichText'
 
 import PageClient from './page.client'
 
-export const dynamic = 'force-static'
-export const revalidate = 600
+export const dynamic = 'force-dynamic'
 
-export async function generateStaticParams() {
-  const payload = await getPayload({ config: configPromise })
-  const posts = await payload.find({
-    collection: 'posts',
-    draft: false,
-    limit: 1000,
-    overrideAccess: false,
-  })
-
-  const params = posts.docs.map(({ slug }) => {
-    return { slug }
-  })
-
-  return params
-}
+// export async function generateStaticParams() {
+//   const payload = await getPayload({ config: configPromise })
+//   const posts = await payload.find({
+//     collection: 'posts',
+//     draft: false,
+//     limit: 1000,
+//     overrideAccess: false,
+//   })
+//
+//   const params = posts.docs.map(({ slug }) => {
+//     return { slug }
+//   })
+//
+//   return params
+// }
 
 type Args = {
   params: Promise<{ lng: string; slug?: string }>


### PR DESCRIPTION
```
### Description

This pull request updates the blog and post pages to use dynamic rendering by setting `dynamic` to `force-dynamic`. Additionally, the `generateStaticParams` function in post pages has been commented out to align with the transition to dynamic rendering.

```