### PR TITLE
feat(search): Populate category data in search index

### DIFF
--- a/src/search/beforeSync.ts
+++ b/src/search/beforeSync.ts
@@ -1,11 +1,11 @@
 import { BeforeSync, DocToSync } from '@payloadcms/plugin-search/types'
 
-export const beforeSyncWithSearch: BeforeSync = async ({ originalDoc, searchDoc, payload }) => {
+export const beforeSyncWithSearch: BeforeSync = async ({ req, originalDoc, searchDoc }) => {
   const {
     doc: { relationTo: collection },
   } = searchDoc
 
-  const { slug, id, categories, title, meta, excerpt } = originalDoc
+  const { slug, id, categories, title, meta } = originalDoc
 
   const modifiedDoc: DocToSync = {
     ...searchDoc,
@@ -20,24 +20,40 @@ export const beforeSyncWithSearch: BeforeSync = async ({ originalDoc, searchDoc,
   }
 
   if (categories && Array.isArray(categories) && categories.length > 0) {
-    // get full categories and keep a flattened copy of their most important properties
-    try {
-      const mappedCategories = categories.map((category) => {
-        const { id, title } = category
+    const populatedCategories: { id: string | number; title: string }[] = []
+    for (const category of categories) {
+      if (!category) {
+        continue
+      }
 
-        return {
-          relationTo: 'categories',
-          id,
-          title,
-        }
+      if (typeof category === 'object') {
+        populatedCategories.push(category)
+        continue
+      }
+
+      const doc = await req.payload.findByID({
+        collection: 'categories',
+        id: category,
+        disableErrors: true,
+        depth: 0,
+        select: { title: true },
+        req,
       })
 
-      modifiedDoc.categories = mappedCategories
-    } catch (err) {
-      console.error(
-        `Failed. Category not found when syncing collection '${collection}' with id: '${id}' to search.`,
-      )
+      if (doc !== null) {
+        populatedCategories.push(doc)
+      } else {
+        console.error(
+          `Failed. Category not found when syncing collection '${collection}' with id: '${id}' to search.`,
+        )
+      }
     }
+
+    modifiedDoc.categories = populatedCategories.map((each) => ({
+      relationTo: 'categories',
+      categoryID: String(each.id),
+      title: each.title,
+    }))
   }
 
   return modifiedDoc


### PR DESCRIPTION
The changes in this commit ensure that the category data is properly populated in the search index. Previously, the code was attempting to map the category IDs to their corresponding titles, but this was causing issues when the categories were not found. 

The new implementation uses a loop to fetch the category data for each ID, and then maps the results to the format expected by the search index. This ensures that the search index contains accurate and complete data, which will improve the quality of search results.