### PR TITLE
fix: prevent slug overwrite on admin locale switch

### DIFF
--- a/src/fields/slug/SlugComponent.tsx
+++ b/src/fields/slug/SlugComponent.tsx
@@ -2,7 +2,15 @@
 import React, { useCallback, useEffect } from 'react'
 import { TextFieldClientProps } from 'payload'
 
-import { useField, Button, TextInput, FieldLabel, useFormFields, useForm } from '@payloadcms/ui'
+import {
+  useField,
+  Button,
+  TextInput,
+  FieldLabel,
+  useFormFields,
+  useForm,
+  useDocumentInfo,
+} from '@payloadcms/ui'
 
 import { formatSlug } from './formatSlug'
 import './index.scss'
@@ -29,6 +37,9 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
 
   const { dispatchFields } = useForm()
 
+  const { id: docId } = useDocumentInfo()
+  const isCreating = !docId
+
   // The value of the checkbox
   // We're using separate useFormFields to minimise re-renders
   const checkboxValue = useFormFields(([fields]) => {
@@ -41,6 +52,7 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
   })
 
   useEffect(() => {
+    if (!isCreating) return
     if (checkboxValue) {
       if (targetFieldValue) {
         const formattedSlug = formatSlug(targetFieldValue)
@@ -50,7 +62,7 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
         if (value !== '') setValue('')
       }
     }
-  }, [targetFieldValue, checkboxValue, setValue, value])
+  }, [targetFieldValue, checkboxValue, setValue, value, isCreating])
 
   const handleLock = useCallback(
     (e) => {
@@ -65,16 +77,18 @@ export const SlugComponent: React.FC<SlugComponentProps> = ({
     [checkboxValue, checkboxFieldPath, dispatchFields],
   )
 
-  const readOnly = readOnlyFromProps || checkboxValue
+  const readOnly = readOnlyFromProps || (isCreating && checkboxValue)
 
   return (
     <div className="field-type slug-field-component">
       <div className="label-wrapper">
         <FieldLabel htmlFor={`field-${path}`} label={label} />
 
-        <Button className="lock-button" buttonStyle="none" onClick={handleLock}>
-          {checkboxValue ? 'Unlock' : 'Lock'}
-        </Button>
+        {isCreating && (
+          <Button className="lock-button" buttonStyle="none" onClick={handleLock}>
+            {checkboxValue ? 'Unlock' : 'Lock'}
+          </Button>
+        )}
       </div>
 
       <TextInput

--- a/src/fields/slug/index.ts
+++ b/src/fields/slug/index.ts
@@ -15,7 +15,7 @@ export const slugField: Slug = (fieldToUse = 'title', overrides = {}) => {
   const checkBoxField: CheckboxField = {
     name: 'slugLock',
     type: 'checkbox',
-    defaultValue: true,
+    defaultValue: false,
     admin: {
       hidden: true,
       position: 'sidebar',


### PR DESCRIPTION
## Summary

- Fix admin bug where switching zh/en locale on an existing post silently overwrote `slug` (a non-localized field shared by both locales) with the new locale's title
- Root cause: `SlugComponent.tsx` `useEffect` fires on `targetFieldValue` (title) change and, when `slugLock=true`, regenerates slug from title. Locale switch mutates title → effect fires → slug corrupted
- Gate auto-sync on `isCreating` (via `useDocumentInfo`) so it only runs during create, never in edit mode
- Flip `slugLock` default to `false` so new posts start with an independent, editable slug
- Keep slug input editable in edit mode regardless of `slugLock`; hide the Lock/Unlock button in edit mode since it no longer has any effect

## Test plan

- [x] Open post id=1972 (or any post with `slugLock=true` in DB) in admin, switch zh ↔ en locale, confirm slug stays unchanged
- [x] Open any existing post in admin, confirm slug input is directly editable without clicking "Unlock"
- [x] Confirm Lock/Unlock button is hidden in edit mode
- [x] Create a new post in admin, type title, confirm slug does **not** auto-fill (behavior change — previously auto-filled)
- [x] On the create form, click "Lock", type in title field, confirm slug auto-syncs from title; click "Unlock", confirm slug becomes editable and title changes no longer sync
- [x] `pnpm tsc --noEmit` passes
- [x] Verify no existing post's slug regresses after deploy (spot-check a few with `GET /posts?where[slugLock][equals]=true&limit=5`)