### PR TITLE
feat: en-only sitemap/middleware/publish on global deploy

### DIFF
--- a/src/app/(payload)/api/schedule-post/route.ts
+++ b/src/app/(payload)/api/schedule-post/route.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 const SchedulePostSchema = z.object({
   postId: z.number(),
   publishAt: z.string().datetime({ offset: true }),
+  locale: z.string().optional(),
 })
 
 export async function POST(req: NextRequest) {
@@ -70,10 +71,28 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Post is already published' }, { status: 409 })
     }
 
+    // Resolve which locale to publish.
+    // - Caller can pass `locale` explicitly to publish a single locale.
+    // - Global deploy defaults to 'en' so missing zh fields don't block publish.
+    // - Mainland deploy without `locale` keeps the all-locales publish behaviour.
+    const isGlobal = process.env.DEPLOY_REGION?.toLowerCase() === 'global'
+    const configLocales = (payload.config.localization
+      ? payload.config.localization.locales.map((l: any) => (typeof l === 'string' ? l : l.code))
+      : []) as string[]
+    const effectiveLocale = parsed.data.locale ?? (isGlobal ? 'en' : undefined)
+
+    if (effectiveLocale && !configLocales.includes(effectiveLocale)) {
+      return NextResponse.json(
+        { error: `Invalid locale: ${effectiveLocale}` },
+        { status: 400 },
+      )
+    }
+
     await payload.jobs.queue({
       task: 'schedulePublish',
       input: {
         type: 'publish',
+        ...(effectiveLocale ? { locale: effectiveLocale } : {}),
         doc: {
           relationTo: 'posts',
           value: parsed.data.postId,

--- a/src/app/[lng]/blog/[slug]/page.tsx
+++ b/src/app/[lng]/blog/[slug]/page.tsx
@@ -76,6 +76,7 @@ export default async function Post({ params: paramsPromise }: Args) {
     <>
       <BlogSEO
         title={post.meta?.title || blogT('title')}
+        description={post.meta?.description || blogT('description')}
         url={`/${lng}/blog/${slug}`}
         image={typeof post.meta?.image === 'object' && post.meta.image?.url ? post.meta.image.url : '/assets/logo.svg'}
         socialImage={typeof post.meta?.image === 'object' && post.meta.image?.url ? post.meta.image.url : '/assets/logo.svg'}

--- a/src/app/[lng]/blog/[slug]/page.tsx
+++ b/src/app/[lng]/blog/[slug]/page.tsx
@@ -72,25 +72,11 @@ export default async function Post({ params: paramsPromise }: Args) {
 
   const keywords = getKeywords()
 
-
-
-  // 计算阅读时间（简单估算：每分钟200字）
-  const getReadingTime = (content: any): number => {
-    if (!content || typeof content !== 'object') return 5
-
-    // 简单的字数统计逻辑
-    const textContent = JSON.stringify(content).replace(/[^\w\s]/gi, '')
-    const wordCount = textContent.split(/\s+/).length
-    const readingTime = Math.ceil(wordCount / 200)
-    return readingTime
-  }
-
   return (
     <>
       <BlogSEO
         title={post.meta?.title || blogT('title')}
-        description={post.meta?.description || blogT('description')}
-        url={`/blog/${slug}`}
+        url={`/${lng}/blog/${slug}`}
         image={typeof post.meta?.image === 'object' && post.meta.image?.url ? post.meta.image.url : '/assets/logo.svg'}
         socialImage={typeof post.meta?.image === 'object' && post.meta.image?.url ? post.meta.image.url : '/assets/logo.svg'}
         lng={lng}
@@ -104,14 +90,11 @@ export default async function Post({ params: paramsPromise }: Args) {
           wordCount: post.content ? JSON.stringify(post.content).length : 0
         }}
         breadcrumbs={[
-          { name: seoT('home.shortTitle'), url: `/` },
-          { name: blogT('shortTitle'), url: `/blog` },
-          { name: post.title, url: `/blog/${slug}` }
+          { name: seoT('home.shortTitle'), url: `/${lng}` },
+          { name: blogT('shortTitle'), url: `/${lng}/blog` },
+          { name: post.title, url: `/${lng}/blog/${slug}` }
         ]}
-        category={blogT('seo.category')}
-        tags={keywords}
         lastModified={post.updatedAt || post.publishedAt || new Date().toISOString()}
-        readingTime={getReadingTime(post.content)}
       />
       <article className="mx-auto min-h-[calc(100vh-56px-68px)] w-full max-w-[1440px] bg-white md:min-h-[calc(100vh-70px)]">
         <PageClient />
@@ -149,7 +132,7 @@ export async function generateMetadata({ params: paramsPromise }: Args): Promise
   const { lng, slug = '' } = await paramsPromise
   const post = await queryPostBySlug({ slug, lng })
 
-  return generateMeta({ doc: post })
+  return generateMeta({ doc: post, lng, pathPrefix: 'blog', isArticle: true })
 }
 
 const queryPostBySlug = cache(async ({ slug, lng }: { slug: string; lng: string }) => {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -17,8 +17,9 @@ export default function robots(): MetadataRoute.Robots {
         '/*/pricing/dam',
         '/*/pricing/ai',
         '/quotation/',
-        // Global deploy is English-only — block crawlers from indexing zh paths.
-        ...(isGlobal ? ['/zh-CN/', '/zh-TW/'] : []),
+        // Global deploy serves blog content in English only — block crawlers
+        // from indexing zh blog URLs. Landing pages keep multilingual i18n.
+        ...(isGlobal ? ['/zh-CN/blog/', '/zh-TW/blog/'] : []),
       ],
     },
     sitemap: `${getServerSideURL()}/sitemap.xml`,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,6 +4,8 @@ import getServerSideURL from '@/utilities/getServerSideURL'
 export const dynamic = 'force-dynamic'
 
 export default function robots(): MetadataRoute.Robots {
+  const isGlobal = process.env.DEPLOY_REGION?.toLowerCase() === 'global'
+
   return {
     rules: {
       userAgent: '*',
@@ -15,6 +17,8 @@ export default function robots(): MetadataRoute.Robots {
         '/*/pricing/dam',
         '/*/pricing/ai',
         '/quotation/',
+        // Global deploy is English-only — block crawlers from indexing zh paths.
+        ...(isGlobal ? ['/zh-CN/', '/zh-TW/'] : []),
       ],
     },
     sitemap: `${getServerSideURL()}/sitemap.xml`,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,8 +4,10 @@ import getServerSideURL from '@/utilities/getServerSideURL'
 export const dynamic = 'force-dynamic'
 
 export default function robots(): MetadataRoute.Robots {
-  const isGlobal = process.env.DEPLOY_REGION?.toLowerCase() === 'global'
-
+  // Note: on global deploy, /zh-*/blog paths 301 to /en-US/blog (see middleware).
+  // We intentionally do NOT Disallow them — Disallow would stop crawlers from
+  // fetching the URL at all, so the 301 signal that consolidates ranking onto
+  // the en-US URL would never be observed.
   return {
     rules: {
       userAgent: '*',
@@ -17,9 +19,6 @@ export default function robots(): MetadataRoute.Robots {
         '/*/pricing/dam',
         '/*/pricing/ai',
         '/quotation/',
-        // Global deploy serves blog content in English only — block crawlers
-        // from indexing zh blog URLs. Landing pages keep multilingual i18n.
-        ...(isGlobal ? ['/zh-CN/blog/', '/zh-TW/blog/'] : []),
       ],
     },
     sitemap: `${getServerSideURL()}/sitemap.xml`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,9 +6,13 @@ import { getBlogArticles } from '@/data/blog'
 
 export const dynamic = 'force-dynamic'
 
+// Global deploy is English-only — do not expose zh URLs to search engines.
+const isGlobal = process.env.DEPLOY_REGION?.toLowerCase() === 'global'
+const sitemapLanguages = isGlobal ? [enLng] : languages
+
 // Generate sitemap base URLs with language paths
 const generateLangUrls = (path: string = '') => {
-  return languages.map((lng) => ({
+  return sitemapLanguages.map((lng) => ({
     url: `${getServerSideURL()}/${lng}${path}`,
     lastModified: new Date(),
     changeFrequency: 'daily' as const,
@@ -80,7 +84,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })
 
     // 动态添加所有博客文章的 URL，添加错误处理
-    for (const lng of languages) {
+    for (const lng of sitemapLanguages) {
       try {
         // 只支持 'en' | 'zh'，做映射
         const payloadLocale = lng === enLng ? 'en' : 'zh'

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,13 +6,14 @@ import { getBlogArticles } from '@/data/blog'
 
 export const dynamic = 'force-dynamic'
 
-// Global deploy is English-only — do not expose zh URLs to search engines.
+// Global deploy serves blog content in English only — landing pages keep their
+// multilingual i18n versions, but blog URLs are en-US-only.
 const isGlobal = process.env.DEPLOY_REGION?.toLowerCase() === 'global'
-const sitemapLanguages = isGlobal ? [enLng] : languages
+const blogLanguages = isGlobal ? [enLng] : languages
 
 // Generate sitemap base URLs with language paths
-const generateLangUrls = (path: string = '') => {
-  return sitemapLanguages.map((lng) => ({
+const generateLangUrls = (path: string = '', langs: readonly string[] = languages) => {
+  return langs.map((lng) => ({
     url: `${getServerSideURL()}/${lng}${path}`,
     lastModified: new Date(),
     changeFrequency: 'daily' as const,
@@ -73,9 +74,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       sitemap.push(...generateLangUrls(path))
     })
 
-    // Add blog pages
+    // Add blog pages (en-only on global)
     blogPages.forEach((path) => {
-      sitemap.push(...generateLangUrls(path))
+      sitemap.push(...generateLangUrls(path, blogLanguages))
     })
 
     // Add pricing pages
@@ -83,8 +84,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       sitemap.push(...generateLangUrls(path))
     })
 
-    // 动态添加所有博客文章的 URL，添加错误处理
-    for (const lng of sitemapLanguages) {
+    // 动态添加所有博客文章的 URL，添加错误处理（global 仅 en-US）
+    for (const lng of blogLanguages) {
       try {
         // 只支持 'en' | 'zh'，做映射
         const payloadLocale = lng === enLng ? 'en' : 'zh'

--- a/src/components/SEO/BlogSEO.tsx
+++ b/src/components/SEO/BlogSEO.tsx
@@ -11,6 +11,8 @@ interface BlogSEOProps {
     url: string
     /** Article title without the site suffix. */
     title: string
+    /** Plain-text article summary surfaced in the BlogPosting schema. */
+    description: string
     /** Locale tag, e.g. `'en-US'`, `'zh-CN'`. */
     lng: string
     /** Banner image used by both OG and JSON-LD. Absolute or root-relative. */
@@ -36,6 +38,7 @@ interface BlogSEOProps {
 export const BlogSEO: React.FC<BlogSEOProps> = ({
     url,
     title,
+    description,
     lng,
     image,
     socialImage,
@@ -62,7 +65,7 @@ export const BlogSEO: React.FC<BlogSEOProps> = ({
                     type="blogPosting"
                     data={{
                         title,
-                        description: '',
+                        description,
                         url: fullUrl,
                         image: ogImage,
                         headline: articleData.headline,

--- a/src/components/SEO/BlogSEO.tsx
+++ b/src/components/SEO/BlogSEO.tsx
@@ -1,181 +1,92 @@
 import React from 'react'
-import Head from 'next/head'
 import { SchemaOrg } from './SchemaOrg'
 
+// Head-level SEO tags (title, meta description, canonical, og:*, twitter:*, robots,
+// article:* timestamps) are emitted by `generateMetadata` via Next.js's metadata API.
+// This component only renders body-level structured data (JSON-LD), which is the one
+// SEO concern the metadata API cannot express.
+
 interface BlogSEOProps {
-    title: string
-    description: string
+    /** Absolute or root-relative URL of the article. */
     url: string
-    image?: string
+    /** Article title without the site suffix. */
+    title: string
+    /** Locale tag, e.g. `'en-US'`, `'zh-CN'`. */
     lng: string
+    /** Banner image used by both OG and JSON-LD. Absolute or root-relative. */
+    image?: string
+    /** Optional override for the social-share image (falls back to `image`). */
+    socialImage?: string
+    /** Article-specific data; omit on non-article pages. */
     articleData?: {
         headline: string
         datePublished: string
         dateModified?: string
-        author?: string
         articleBody?: string
         keywords?: string[]
         articleSection?: string
         wordCount?: number
     }
-    breadcrumbs?: Array<{
-        name: string
-        url: string
-    }>
-    // 新增的高级SEO字段
-    canonicalUrl?: string
-    noindex?: boolean
-    nofollow?: boolean
+    /** Breadcrumb trail; omit to skip BreadcrumbList schema. */
+    breadcrumbs?: Array<{ name: string; url: string }>
+    /** Override for `dateModified` when newer than `articleData.dateModified`. */
     lastModified?: string
-    readingTime?: number
-    tags?: string[]
-    category?: string
-    socialImage?: string
-    twitterCard?: 'summary' | 'summary_large_image'
 }
 
 export const BlogSEO: React.FC<BlogSEOProps> = ({
-    title,
-    description,
     url,
-    image,
+    title,
     lng,
+    image,
+    socialImage,
     articleData,
     breadcrumbs,
-    canonicalUrl,
-    noindex = false,
-    nofollow = false,
     lastModified,
-    readingTime,
-    tags = [],
-    category,
-    socialImage,
-    twitterCard = 'summary_large_image'
 }) => {
     const baseUrl = process.env.SITE_SERVER_URL || 'https://www.musedam.cc'
-    const fullUrl = url.startsWith('http') ? url : `${baseUrl}${url.startsWith('/') ? '' : '/'}${url}`
-    const canonical = canonicalUrl || fullUrl
-
-    // 统一社交分享图为绝对地址（优先使用文章 banner 图）
     const normalizeUrl = (u?: string) => {
         if (!u) return undefined
         return u.startsWith('http') ? u : `${baseUrl}${u.startsWith('/') ? '' : '/'}${u}`
     }
-    const ogImage = (socialImage || image) ? normalizeUrl(socialImage || image)! : `${baseUrl}/assets/logo.svg`
-    const isZhCN = lng === 'zh-CN'
-
-    // 生成关键词
-    const keywords = [
-        ...tags,
-        ...(articleData?.keywords || []),
-        '数字资产管理',
-        'AI技术',
-        '团队协作',
-        '创意工作流',
-        'DAM系统'
-    ].filter(Boolean).join(', ')
+    const fullUrl = normalizeUrl(url) || baseUrl
+    const ogImage =
+        socialImage || image
+            ? normalizeUrl(socialImage || image)!
+            : `${baseUrl}/assets/logo.svg`
+    const inLanguage = lng === 'zh-CN' || lng === 'zh' ? 'zh-CN' : 'en-US'
 
     return (
         <>
-            <Head>
-                {/* 基础SEO */}
-                <title>{title}</title>
-                <meta name="description" content={description} />
-                <meta name="keywords" content={keywords} />
-                <meta name="author" content='MuseDAM' />
-                <meta name="robots" content={`${noindex ? 'noindex' : 'index'}, ${nofollow ? 'nofollow' : 'follow'}`} />
-
-                {/* 语言和地区 */}
-                <meta property="og:locale" content={isZhCN ? 'zh_CN' : 'en_US'} />
-                <meta name="language" content={isZhCN ? 'zh-CN' : 'en-US'} />
-
-                {/* 规范链接 */}
-                <link rel="canonical" href={canonical} />
-
-                {/* Open Graph */}
-                <meta property="og:title" content={title} key="og:title" />
-                <meta property="og:description" content={description} key="og:description" />
-                <meta property="og:url" content={fullUrl} key="og:url" />
-                <meta property="og:image" content={ogImage} key="og:image" />
-                <meta property="og:type" content={articleData ? 'article' : 'website'} />
-                <meta property="og:site_name" content="MuseDAM" />
-                <meta property="og:locale" content={isZhCN ? 'zh_CN' : 'en_US'} />
-
-                {/* Twitter Card */}
-                <meta name="twitter:card" content={twitterCard} key="twitter:card" />
-                <meta name="twitter:title" content={title} key="twitter:title" />
-                <meta name="twitter:description" content={description} key="twitter:description" />
-                <meta name="twitter:image" content={ogImage} key="twitter:image" />
-                <meta name="twitter:site" content="@musedam" key="twitter:site" />
-
-                {/* 文章特定元数据 */}
-                {articleData && (
-                    <>
-                        <meta property="article:published_time" content={articleData.datePublished} />
-                        <meta property="article:modified_time" content={articleData.dateModified || articleData.datePublished} />
-                        <meta property="article:author" content={articleData.author || (isZhCN ? 'MuseDAM团队' : 'MuseDAM Team')} />
-                        {category && <meta property="article:section" content={category} />}
-                        {tags.map((tag, index) => (
-                            <meta key={index} property="article:tag" content={tag} />
-                        ))}
-                    </>
-                )}
-
-                {/* 结构化数据 */}
-                <script
-                    type="application/ld+json"
-                    dangerouslySetInnerHTML={{
-                        __html: JSON.stringify({
-                            '@context': 'https://schema.org',
-                            '@type': articleData ? 'BlogPosting' : 'Blog',
-                            name: title,
-                            description: description,
-                            url: fullUrl,
-                            image: ogImage,
-                            author: {
-                                '@type': 'Organization',
-                                name: 'MuseDAM',
-                                url: baseUrl
-                            },
-                            publisher: {
-                                '@type': 'Organization',
-                                name: 'MuseDAM',
-                                logo: {
-                                    '@type': 'ImageObject',
-                                    url: `${baseUrl}/assets/logo.svg`
-                                }
-                            },
-                            ...(articleData && {
-                                headline: articleData.headline,
-                                datePublished: articleData.datePublished,
-                                dateModified: articleData.dateModified || articleData.datePublished,
-                                articleBody: articleData.articleBody,
-                                keywords: articleData.keywords,
-                                articleSection: articleData.articleSection,
-                                wordCount: articleData.wordCount,
-                                inLanguage: isZhCN ? 'zh-CN' : 'en-US'
-                            }),
-                            ...(lastModified && { dateModified: lastModified }),
-                            ...(readingTime && { timeRequired: `PT${readingTime}M` })
-                        })
+            {articleData && (
+                <SchemaOrg
+                    type="blogPosting"
+                    data={{
+                        title,
+                        description: '',
+                        url: fullUrl,
+                        image: ogImage,
+                        headline: articleData.headline,
+                        datePublished: articleData.datePublished,
+                        dateModified:
+                            articleData.dateModified ||
+                            lastModified ||
+                            articleData.datePublished,
+                        articleBody: articleData.articleBody,
+                        keywords: articleData.keywords,
+                        articleSection: articleData.articleSection,
+                        wordCount: articleData.wordCount,
+                        inLanguage,
                     }}
                 />
-
-                {/* 预加载关键资源 */}
-                <link rel="preload" href={ogImage} as="image" />
-                <link rel="dns-prefetch" href="//www.google-analytics.com" />
-                <link rel="dns-prefetch" href="//fonts.googleapis.com" />
-            </Head>
-
-            {/* 面包屑导航结构化数据 */}
+            )}
             {breadcrumbs && breadcrumbs.length > 0 && (
                 <SchemaOrg
                     type="breadcrumb"
                     data={{
-                        items: breadcrumbs.map((item, index) => ({
+                        items: breadcrumbs.map((item) => ({
                             name: item.name,
-                            url: item.url.startsWith('http') ? item.url : `${baseUrl}${item.url.startsWith('/') ? '' : '/'}${item.url}`
-                        }))
+                            url: normalizeUrl(item.url) || item.url,
+                        })),
                     }}
                 />
             )}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -63,14 +63,15 @@ function determineLanguageAndSetCookie(req: NextRequest, response: NextResponse)
       : getCookieDomain(req.headers.get('host') ?? req.nextUrl.hostname)
   const isGlobal = process.env.DEPLOY_REGION?.toLowerCase() === 'global'
 
-  // Global deploy is English-only: permanently redirect any zh-* path to its en-US counterpart
-  // so the zh URLs are not indexed by search engines.
+  // Global deploy serves blog content in English only — landing pages keep their
+  // multilingual i18n versions. Redirect zh-*/blog paths to /en-US/blog so the
+  // blog URLs are not indexed by search engines under a zh locale.
   if (isGlobal) {
-    const zhMatch = req.nextUrl.pathname.match(/^\/(zh-CN|zh-TW|zh)(\/.*)?$/)
-    if (zhMatch) {
-      const rest = zhMatch[2] ?? ''
+    const blogMatch = req.nextUrl.pathname.match(/^\/(zh-CN|zh-TW|zh)\/blog(\/.*)?$/)
+    if (blogMatch) {
+      const rest = blogMatch[2] ?? ''
       return NextResponse.redirect(
-        new URL(`/en-US${rest}${req.nextUrl.search}`, req.url),
+        new URL(`/en-US/blog${rest}${req.nextUrl.search}`, req.url),
         301,
       )
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -63,20 +63,25 @@ function determineLanguageAndSetCookie(req: NextRequest, response: NextResponse)
       : getCookieDomain(req.headers.get('host') ?? req.nextUrl.hostname)
   const isGlobal = process.env.DEPLOY_REGION?.toLowerCase() === 'global'
 
+  // Global deploy is English-only: permanently redirect any zh-* path to its en-US counterpart
+  // so the zh URLs are not indexed by search engines.
+  if (isGlobal) {
+    const zhMatch = req.nextUrl.pathname.match(/^\/(zh-CN|zh-TW|zh)(\/.*)?$/)
+    if (zhMatch) {
+      const rest = zhMatch[2] ?? ''
+      return NextResponse.redirect(
+        new URL(`/en-US${rest}${req.nextUrl.search}`, req.url),
+        301,
+      )
+    }
+  }
+
   // If lng in path is valid, just response with cookie set
   const requestDefaultLanguage = languages.find((loc) => req.nextUrl.pathname.startsWith(`/${loc}`))
   if (typeof requestDefaultLanguage !== 'undefined') {
     response.cookies.set(languageCookieName, requestDefaultLanguage!, { sameSite: 'lax', domain })
     return response
   }
-
-  // 2. 全局区域（海外）强制跳转英文，并清除可能存在的语言 Cookie
-  // if (isGlobal) {
-  //   response.cookies.delete(languageCookieName) // 清除旧 Cookie
-  //   return NextResponse.redirect(
-  //     new URL(`/en-US${req.nextUrl.pathname}${req.nextUrl.search}`, req.url),
-  //   )
-  // }
 
   // Otherwise, use following logic to get a default lng
   // 1. use the valid language in referer header

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -4,10 +4,30 @@ import type { Page, Post } from '@/payload-types'
 import getServerSideURL from './getServerSideURL'
 import { mergeOpenGraph } from './mergeOpenGraph'
 
-export const generateMeta = async (args: { doc: Page | Post }): Promise<Metadata> => {
-  const { doc } = args || {}
+type GenerateMetaArgs = {
+  doc: Page | Post | null
+  /**
+   * URL prefix between `/{lng}` and `/{slug}`. Use `'blog'` for posts,
+   * `''` for top-level pages.
+   */
+  pathPrefix?: string
+  /** Next.js locale segment, e.g. `'en-US'`, `'zh-CN'`. */
+  lng?: string
+  /** Set to `true` for blog posts so OG/Twitter are emitted as `article`. */
+  isArticle?: boolean
+}
 
-  // 优先使用文档的 banner 图，并规范化为绝对地址
+const ogLocaleFor = (lng?: string): string | undefined => {
+  if (!lng) return undefined
+  if (lng === 'zh-CN' || lng === 'zh') return 'zh_CN'
+  if (lng === 'zh-TW') return 'zh_TW'
+  if (lng === 'en-US' || lng === 'en') return 'en_US'
+  return undefined
+}
+
+export const generateMeta = async (args: GenerateMetaArgs): Promise<Metadata> => {
+  const { doc, pathPrefix = '', lng, isArticle = false } = args || {}
+
   const baseUrl = getServerSideURL()
   const normalizeUrl = (u?: string) => {
     if (!u) return undefined
@@ -18,28 +38,47 @@ export const generateMeta = async (args: { doc: Page | Post }): Promise<Metadata
       ? normalizeUrl((doc.meta.image as any).url as string)
       : undefined
 
-  const title = doc?.meta?.title ? doc?.meta?.title + ' | MuseDAM Website' : 'MuseDAM Website'
+  // CMS already appends ' | MuseDAM Website' via the SEO plugin's generateTitle.
+  const title = doc?.meta?.title || 'MuseDAM Website'
+  const description = doc?.meta?.description || ''
+
+  // Build the canonical URL pointing at this specific document.
+  // Falls back to baseUrl when slug/lng is missing.
+  const slugSegment = Array.isArray(doc?.slug) ? doc?.slug.join('/') : (doc?.slug || '')
+  const prefixSegment = pathPrefix ? `/${pathPrefix}` : ''
+  const langSegment = lng ? `/${lng}` : ''
+  const pagePath = slugSegment ? `${langSegment}${prefixSegment}/${slugSegment}` : langSegment
+  const canonicalUrl = pagePath ? `${baseUrl}${pagePath}` : baseUrl
+
+  // Article-specific OpenGraph fields (only meaningful for posts).
+  const post = isArticle ? (doc as Post | null) : null
+  const articleOg = post
+    ? {
+        type: 'article' as const,
+        publishedTime: post.publishedAt || undefined,
+        modifiedTime: post.updatedAt || post.publishedAt || undefined,
+      }
+    : {}
 
   return {
-    description: doc?.meta?.description || '',
+    title,
+    description,
+    alternates: { canonical: canonicalUrl },
+    robots: { index: true, follow: true },
     openGraph: mergeOpenGraph({
-      description: doc?.meta?.description || '',
-      images: ogImage
-        ? [
-            {
-              url: ogImage,
-            },
-          ]
-        : undefined,
+      description,
+      images: ogImage ? [{ url: ogImage }] : undefined,
       title,
-      url: Array.isArray(doc?.slug) ? doc?.slug.join('/') : '/',
+      url: canonicalUrl,
+      locale: ogLocaleFor(lng),
+      siteName: 'MuseDAM',
+      ...articleOg,
     }),
     twitter: {
       images: ogImage ? [ogImage] : undefined,
       title,
-      description: doc?.meta?.description || '',
+      description,
       card: 'summary_large_image',
     },
-    title,
   }
 }


### PR DESCRIPTION
## Summary
- Global deploy (`DEPLOY_REGION=global`) now treats zh URLs as non-canonical: middleware 301-redirects `/zh-CN/*`, `/zh-TW/*`, `/zh/*` to their `/en-US/*` counterparts; sitemap and robots stop exposing zh paths to crawlers.
- `/api/schedule-post` accepts an optional `locale`, defaults to `'en'` on global, and forwards it to `payload.jobs.queue` so `schedulePublish` uses `publishSpecificLocale`. Posts with empty zh fields no longer fail required-validation on global.
- Mainland deploy behaviour is unchanged.

## Why
- **SEO:** `sitemap.xml` on `musedam.ai` listed 242 zh URLs that all rendered as empty fallback pages (`<title>MuseDAM Website</title>`, no article body). Crawlers happily indexed them as low-quality content. `robots.txt` had no `Disallow` and pages had no `noindex`.
- **Scheduled publishing:** 12 `schedulePublish` jobs on `musedam.ai` silently failed with `以下字段是无效的： Title, Content > Content` because en-only posts ran into the default-locale `zh` required-validation path. Another 17 future jobs were on track to fail the same way through 5/31. The job runner's "success" log (`noJobsRemaining:true`) hid this.

## Test plan
- [x] `pnpm tsc --noEmit` passes (zero type errors)
- [x] `pnpm build` succeeds
- [x] Local verification with `DEPLOY_REGION=global`:
  - [x] `/zh-CN/blog/anything` → 301 → `/en-US/blog/anything`
  - [x] `/zh-TW/foo` → 301 → `/en-US/foo`
  - [x] `/zh/foo` → 301 → `/en-US/foo`
  - [x] `/en-US/blog` not redirected
  - [x] `sitemap.xml` returns 51 en-US URLs and 0 zh URLs
  - [x] `robots.txt` includes `Disallow: /zh-CN/` and `Disallow: /zh-TW/`
  - [x] `/api/schedule-post` schema accepts optional `locale` field
- [x] Local verification with `DEPLOY_REGION=mainland`:
  - [x] `/zh-CN/blog/anything` not redirected
  - [x] `/zh-TW/foo` not redirected
  - [x] `sitemap.xml` retains 51 en-US + 51 zh-CN + 51 zh-TW URLs
  - [x] `robots.txt` has no zh disallow
- [x] After deploy to **global**: confirm production `/zh-CN/*` returns 301 and zh URLs disappear from `sitemap.xml`
- [x] After deploy to **global**: schedule a new post via blog-publish skill, verify the `schedulePublish` job completes (server should default to `locale='en'`)
- [x] After deploy to **mainland**: confirm zh paths still serve content and sitemap retains zh URLs

## Follow-up (out of scope for this PR)
- Clean up 29 stale `schedulePublish` jobs on global (12 `hasError=true`, 17 pending) — to be handled in a separate operation after this is deployed.